### PR TITLE
Added localeCompare option for string comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ syntactic sugar.
 
 ```javascript
 query
-  .orderBy(comparator) // or .sort(comparator)
+  .orderBy(comparator[, options]) // or .sort(comparator[, options])
 ```
 
 #### Arguments
@@ -301,6 +301,16 @@ query
   - If an array of property names is passed in, then the query elements are
     sorted in ascending order by each property in sequence, following the same
     logic on each property as described above.
+- `options` (object)
+  - *Optional*
+  - Object containing the following properties:
+    - `localeCompare` (boolean): If `true`, this signifies that strings should
+      be sorted using the `localeCompare` function. If `false` (default),
+      strings are sorted according to each character's Unicode code point value.
+      This parameter is only used if `comparator` is a string or an array of
+      property names.  Setting this parameter to `true` results in  generally
+      slower sorts for string properties, but may be necessary if the properties
+      are locale-sensitive.
 
 #### Returns
 
@@ -523,6 +533,13 @@ query
     - `sorted` (boolean): If `true`, this signifies that both input arrays are
       already sorted according to `comparator`. This provides a significant
       performance boost. Default is `false`.
+    - `localeCompare` (boolean): If `true`, this signifies that strings should
+      be sorted using the `localeCompare` function. If `false` (default),
+      strings are sorted according to each character's Unicode code point value.
+      This parameter is only used if `comparator` is a string or an array of
+      property names.  Setting this parameter to `true` results in  generally
+      slower sorts for string properties, but may be necessary if the properties
+      are locale-sensitive.
 
 #### Returns
 
@@ -646,6 +663,13 @@ query
     - `sorted` (boolean): If `true`, this signifies that both input arrays are
       already sorted according to `comparator`. This provides a significant
       performance boost. Default is `false`.
+    - `localeCompare` (boolean): If `true`, this signifies that strings should
+      be sorted using the `localeCompare` function. If `false` (default),
+      strings are sorted according to each character's Unicode code point value.
+      This parameter is only used if `comparator` is a string or an array of
+      property names.  Setting this parameter to `true` results in  generally
+      slower sorts for string properties, but may be necessary if the properties
+      are locale-sensitive.
 
 #### Returns
 

--- a/angular-join.js
+++ b/angular-join.js
@@ -28,14 +28,26 @@ angular.module('angular-join', [])
     }
   }
 
-  function normalizeComparator(comparator) {
+  function normalizeComparator(comparator, options) {
+    var stringCompare;
+    if (options && options.localeCompare) {
+      stringCompare = function(s1, s2) {
+        return s1.localeCompare(s2);
+      }
+    } else {
+      stringCompare = function(s1, s2) {
+        return s1 < s2 ? -1 : s1 > s2 ? 1 : 0;
+      }
+    }
+
     if (typeof comparator == 'string' || comparator instanceof String) {
       if (comparator instanceof String) {
         comparator = comparator.valueOf();
       }
+
       return function(e1, e2) {
-        if (typeof e1[comparator].localeCompare == 'function') {
-          return e1[comparator].localeCompare(e2[comparator]);
+        if (typeof e1[comparator] == 'string' || e1[comparator] instanceof String) {
+          return stringCompare(e1[comparator], e2[comparator]);
         } else if (typeof e1[comparator].diff == 'function') {
           return e1[comparator].diff(e2[comparator]);
         } else {
@@ -46,8 +58,8 @@ angular.module('angular-join', [])
       return function(e1, e2) {
         var result = 0;
         comparator.some(function(prop) {
-          if (typeof e1[prop].localeCompare == 'function') {
-            result = e1[prop].localeCompare(e2[prop]);
+          if (typeof e1[prop] == 'string' || e1[prop] instanceof String) {
+            result = stringCompare(e1[prop], e2[prop]);
           } else if (typeof e1[prop].diff == 'function') {
             result = e1[prop].diff(e2[prop]);
           } else {
@@ -90,7 +102,7 @@ angular.module('angular-join', [])
     var a1 = this;
     var a3 = [];
 
-    comparator = normalizeComparator(comparator);
+    comparator = normalizeComparator(comparator, options);
 
     if (!options || !options.sorted) {
       a1 = a1.slice().sort(comparator);
@@ -261,7 +273,7 @@ angular.module('angular-join', [])
       return results;
     }
 
-    comparator = normalizeComparator(comparator);
+    comparator = normalizeComparator(comparator, options);
 
     if (!options || !options.sorted) {
       a = a.slice().sort(comparator);
@@ -348,10 +360,10 @@ angular.module('angular-join', [])
         // just an alias for filter
         return this.filter(callback);
       },
-      sort: function(comparator) {
+      sort: function(comparator, options) {
         this.ops.push([function sortCopy(comparator) {
           return this.slice().sort(comparator);
-        }, normalizeComparator(comparator)]);
+        }, normalizeComparator(comparator, options)]);
         return this;
       },
       orderBy: function(comparator) {

--- a/test/unit/join.spec.js
+++ b/test/unit/join.spec.js
@@ -20,6 +20,20 @@ describe('joining two arrays', function() {
     { x: 5, y: 5, z: 8 }
   ];
 
+  var leftString =  [
+    { x: 'a', y: 1 },
+    { x: 'b', y: 2 },
+    { x: 'c', y: 3 },
+    { x: 'd', y: 4 }
+  ];
+
+  var rightString = [
+    { x: 'a', y: 1, z: 5 },
+    { x: 'b', y: 2, z: 6 },
+    { x: 'c', y: 3, z: 7 },
+    { x: 'e', y: 5, z: 8 }
+  ];
+
   function hashFcn(e) {
     return e.x;
   }
@@ -179,8 +193,122 @@ describe('joining two arrays', function() {
         { x1: 4, x2: 3, y1: 4, y2: 3, z: 7 },
         { x1: 4, x2: 5, y1: 4, y2: 5, z: 8 }
       ]
-    }
+    },
 
+    {
+      name: 'inner join with string values',
+      left: leftString, right: rightString,
+      field: 'x', fields: ['x', 'y'],
+      options: [null, { localeCompare: true }],
+      join: function(e1, e2) {
+        if (e1 && e2) {
+          return {
+            x: e1.x,
+            y: e1.y,
+            z: e2.z
+          };
+        } else {
+          return null;
+        }
+      },
+      expected: [
+        { x: 'a', y: 1, z: 5 },
+        { x: 'b', y: 2, z: 6 },
+        { x: 'c', y: 3, z: 7 }
+      ]
+    },
+    {
+      name: 'left outer join with string values',
+      left: leftString, right: rightString,
+      field: 'x', fields: ['x', 'y'],
+      options: [null, { localeCompare: true }],
+      join: function(e1, e2) {
+        if (e1 && e2) {
+          return {
+            x: e1.x,
+            y: e1.y,
+            z: e2.z
+          };
+        } else if (e1) {
+          return {
+            x: e1.x,
+            y: e1.y,
+            z: null
+          };
+        } else {
+          return null;
+        }
+      },
+      expected: [
+        { x: 'a', y: 1, z: 5 },
+        { x: 'b', y: 2, z: 6 },
+        { x: 'c', y: 3, z: 7 },
+        { x: 'd', y: 4, z: null }
+      ]
+    },
+    {
+      name: 'right outer join with string values',
+      left: leftString, right: rightString,
+      field: 'x', fields: ['x', 'y'],
+      options: [null, { localeCompare: true }],
+      join: function(e1, e2) {
+        if (e1 && e2) {
+          return {
+            x: e1.x,
+            y: e1.y,
+            z: e2.z
+          };
+        } else if (e2) {
+          return {
+            x: e2.x,
+            y: null,
+            z: e2.z
+          };
+        } else {
+          return null;
+        }
+      },
+      expected: [
+        { x: 'a', y: 1,    z: 5 },
+        { x: 'b', y: 2,    z: 6 },
+        { x: 'c', y: 3,    z: 7 },
+        { x: 'e', y: null, z: 8 }
+      ]
+    },
+    {
+      name: 'full outer join with string values',
+      left: leftString, right: rightString,
+      field: 'x', fields: ['x', 'y'],
+      options: [null, { localeCompare: true }],
+      join: function(e1, e2) {
+        if (e1 && e2) {
+          return {
+            x: e1.x,
+            y: e1.y,
+            z: e2.z
+          };
+        } else if (e1) {
+          return {
+            x: e1.x,
+            y: e1.y,
+            z: null
+          };
+        } else {
+          return {
+            x: e2.x,
+            y: null,
+            z: e2.z
+          };
+        }
+      },
+      expected: [
+        { x: 'a', y: 1,    z: 5 },
+        { x: 'b', y: 2,    z: 6 },
+        { x: 'c', y: 3,    z: 7 },
+        { x: 'd', y: 4,    z: null },
+        { x: 'e', y: null, z: 8 }
+      ]
+    }
   ];
 
   describe('using a hash-join algorithm', function() {
@@ -275,26 +403,32 @@ describe('joining two arrays', function() {
     describe('called statically', function() {
       tests.forEach(function(t) {
         describe('should do ' + t.name, function() {
-          if (t.hasOwnProperty('comparator')) {
-            it('with a function', function() {
-              var result = Join.mergeJoin(t.left, t.right, t.comparator, t.join);
-              expect(result).toEqual(t.expected);
-            });
-          }
+          var options = t.options || [null];
 
-          if (t.hasOwnProperty('field')) {
-            it('with a string', function() {
-              var result = Join.mergeJoin(t.left, t.right, t.field, t.join);
-              expect(result).toEqual(t.expected);
-            });
-          }
+          options.forEach(function(opt) {
+          describe('with ' + JSON.stringify(opt) + ' options', function() {
+            if (t.hasOwnProperty('comparator')) {
+              it('with a function', function() {
+                var result = Join.mergeJoin(t.left, t.right, t.comparator, t.join, opt);
+                expect(result).toEqual(t.expected);
+              });
+            }
 
-          if (t.hasOwnProperty('fields')) {
-            it('with an array', function() {
-              var result = Join.mergeJoin(t.left, t.right, t.fields, t.join);
-              expect(result).toEqual(t.expected);
-            });
-          }
+            if (t.hasOwnProperty('field')) {
+              it('with a string', function() {
+                var result = Join.mergeJoin(t.left, t.right, t.field, t.join, opt);
+                expect(result).toEqual(t.expected);
+              });
+            }
+
+            if (t.hasOwnProperty('fields')) {
+              it('with an array', function() {
+                var result = Join.mergeJoin(t.left, t.right, t.fields, t.join, opt);
+                expect(result).toEqual(t.expected);
+              });
+            }
+          });
+          });
         });
       });
     });
@@ -302,35 +436,41 @@ describe('joining two arrays', function() {
     describe('called fluently', function() {
       tests.forEach(function(t) {
         describe('should do ' + t.name, function() {
-          if (t.hasOwnProperty('comparator')) {
-            it('with a function', function() {
-              var result = Join
-                .selectFrom(t.left)
-                .mergeJoin(t.right, t.comparator, t.join)
-                .execute();
-              expect(result).toEqual(t.expected);
-            });
-          }
+          var options = t.options || [null];
 
-          if (t.hasOwnProperty('field')) {
-            it('with a string', function() {
-              var result = Join
-                .selectFrom(t.left)
-                .mergeJoin(t.right, t.field, t.join)
-                .execute();
-              expect(result).toEqual(t.expected);
-            });
-          }
+          options.forEach(function(opt) {
+          describe('with ' + JSON.stringify(opt) + ' options', function() {
+            if (t.hasOwnProperty('comparator')) {
+              it('with a function', function() {
+                var result = Join
+                  .selectFrom(t.left)
+                  .mergeJoin(t.right, t.comparator, t.join, opt)
+                  .execute();
+                expect(result).toEqual(t.expected);
+              });
+            }
 
-          if (t.hasOwnProperty('fields')) {
-            it('with an array', function() {
-              var result = Join
-                .selectFrom(t.left)
-                .mergeJoin(t.right, t.fields, t.join)
-                .execute();
-              expect(result).toEqual(t.expected);
-            });
-          }
+            if (t.hasOwnProperty('field')) {
+              it('with a string', function() {
+                var result = Join
+                  .selectFrom(t.left)
+                  .mergeJoin(t.right, t.field, t.join, opt)
+                  .execute();
+                expect(result).toEqual(t.expected);
+              });
+            }
+
+            if (t.hasOwnProperty('fields')) {
+              it('with an array', function() {
+                var result = Join
+                  .selectFrom(t.left)
+                  .mergeJoin(t.right, t.fields, t.join, opt)
+                  .execute();
+                expect(result).toEqual(t.expected);
+              });
+            }
+          });
+          });
         });
       });
     });


### PR DESCRIPTION
Fixes #10 

The options object for mergeJoin, sortGroupBy, and orderBy/sort now supports a
localeCompare boolean property (default false). If true, it uses localeCompare
to do the comparison; otherwise, it does a Unicode code point comparison
(i.e. the < and > operators). The localeCompare option is much slower, but
necessary in cases where locale ordering is important.

The testspec for Join was updated to include string-keyed joins, with and
without the new localeCompare option.
