### PR TITLE
Define queries recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ Join
 
 #### Arguments
 
-- `input` (array)
-  - The input array to start the query.
+- `input` (array/JoinQuery)
+  - If an array, the input array to start the query.
+  - If a JoinQuery, the result of that query is used to start this query.
 - `callback` (function/string/array)
   - *Optional*
   - Function executed as `callback(e)`, where `e` is an element of `input`.
@@ -446,8 +447,10 @@ query
 
 #### Arguments
 
-- `right` (array)
-  - The righthand array in the join operation.
+- `right` (array/JoinQuery)
+  - If an array, the righthand array in the join operation.
+  - If a JoinQuery, the result of that query is used as the righthand array in
+    the join operation.
 - `hashFcn` (function/string/array)
   - Function executed as `hashFcn(e)`, where `e` is an element of the current
     query result (the "left" array) or `right`, and returning a number or
@@ -509,8 +512,10 @@ query
 
 #### Arguments
 
-- `right` (array)
-  - The righthand array in the join operation.
+- `right` (array/JoinQuery)
+  - If an array, the righthand array in the join operation.
+  - If a JoinQuery, the result of that query is used as the righthand array in
+    the join operation.
 - `comparator` (function/string/array)
   - Function executed as `comparator(e1, e2)`, where `e1` and `e2` are
     elements of the current query result (the "left" array) and `right`,

--- a/README.md
+++ b/README.md
@@ -68,15 +68,21 @@ an array as the starting data on which to perform subsequent operations.
 **all operations create a new array to be returned or passed in as the input**
 **of the next operation.**
 
-None of the operations in the query are performed until the `.execute()`
+None of the operations in the query are performed until the `execute`
 function is called, which returns the array resulting from sequentially running
 all the operations queued on the query, which allows them to be constructed in
 one place and executed in another. If called with the `{async: true}` option,
 a [promise object][] is returned instead, which is resolved with the final
-array and notified with the intermediate results of each operation in the query.
+array.
 
-Query objects are instances of `JoinQuery` and are immutable; each operation
-(with the exception of `execute`) results in the creation of a new object.
+Query objects are instances of `JoinQuery` and each operation (with the
+exception of `execute`) results in the creation of a new object. The first time
+that `execute` is called, the results of the query (and all queries on which
+this one is dependent) are cached, and subsequent calls return the cached
+results instead of recalculating them. This results in more efficient queries,
+especially when one query uses another as its starting point. However, if inputs
+change in between calls to `execute`, the cached results may become stale and
+`execute` should be called with the `{force: true}` option.
 
 
 ### selectFrom
@@ -144,10 +150,13 @@ SELECT ...
 Runs the query and returns the resulting array, or a [promise object][]
 that resolves to the resulting array (see `options` below).
 
-This function may be called more than once on the same query, but in
-non-asynchronous mode (which is the default), the query operations are
-re-executed each time it is called; therefore, it is more efficient in these
-cases to call it once and save the result.
+This function may be called more than once on the same query. The first time
+it is called, the results of the query (and all queries on which this one is
+dependent) are cached, and subsequent calls return the cached results instead
+of recalculating them. This results in more efficient queries, especially when
+one query uses another as its starting point. However, if inputs change in
+between calls, the cached results may become stale and `execute` should be
+called with the `{force: true}` option (see `options` below).
 
 
 #### Syntax
@@ -164,17 +173,20 @@ query
   - Object containing the following properties:
     - `async` (boolean): If true, then instead of returning the resulting
       array, execute the query asynchronously and return a [promise object][]
-      that resolves to the resulting array. The promise's notify callback will
-      be called on each intermediate array returned by each operation in the
-      query, which may be used for debugging. Default is false.
+      that resolves to the resulting array. Default is false.
+    - `force` (boolean): If false, then cached results (if available) from the
+      last call to `execute` are returned. This results in faster queries,
+      but may return stale results if any input arrays have changed since the
+      last execution. If true, then the query is re-executed and its cache (and
+      those of all queries on which this one is dependent) is updated. Default
+      is false.
 
 #### Returns
 
 - array/promise
   - If the `{async: true}` option was not used, the array resulting from
     executing the query is returned. Otherwise, a [promise object][] is
-    returned that resolves to the resulting array, which also gets notified
-    with the intermediate arrays returned by each operation in the query.
+    returned that resolves to the resulting array.
 
 ---
 
@@ -296,7 +308,7 @@ query
     case with every query operation).
   - If a string is passed in, then the query elements are sorted by that
     property in ascending order. If the property itself is a string, then
-    [String.prototype.localeCompare()][] is used to sort the query results; if
+    the sorting strategy is determined by the `localeCompare` option; if
     the property is an object with a `diff()` function, then this function is
     expected to have the same spec as the callback in
     [Array.prototype.sort()][], and it is used to sort the query results.
@@ -308,12 +320,12 @@ query
   - *Optional*
   - Object containing the following properties:
     - `localeCompare` (boolean): If `true`, this signifies that strings should
-      be sorted using the `localeCompare` function. If `false` (default),
-      strings are sorted according to each character's Unicode code point value.
-      This parameter is only used if `comparator` is a string or an array of
-      property names.  Setting this parameter to `true` results in  generally
-      slower sorts for string properties, but may be necessary if the properties
-      are locale-sensitive.
+      be sorted using the [String.prototype.localeCompare()][] function. If
+      `false` (default), strings are sorted according to each character's
+      Unicode code point value. This parameter is only used if `comparator` is
+      a string or an array of property names. Setting this parameter to `true`
+      results in generally slower sorts for string properties, but may be
+      necessary if the properties are locale-sensitive.
 
 #### Returns
 
@@ -508,7 +520,7 @@ query
     function.
   - If a string is passed in, then the query elements are sorted by that
     property in ascending order. If the property itself is a string, then
-    [String.prototype.localeCompare()][] is used to sort the query results; if
+    the sorting strategy is determined by the `localeCompare` option; if
     the property is an object with a `diff()` function, then this function is
     expected to have the same spec as the callback in
     [Array.prototype.sort()][], and it is used to sort the query results.
@@ -537,12 +549,12 @@ query
       already sorted according to `comparator`. This provides a significant
       performance boost. Default is `false`.
     - `localeCompare` (boolean): If `true`, this signifies that strings should
-      be sorted using the `localeCompare` function. If `false` (default),
-      strings are sorted according to each character's Unicode code point value.
-      This parameter is only used if `comparator` is a string or an array of
-      property names.  Setting this parameter to `true` results in  generally
-      slower sorts for string properties, but may be necessary if the properties
-      are locale-sensitive.
+      be sorted using the [String.prototype.localeCompare()][] function. If
+      `false` (default), strings are sorted according to each character's
+      Unicode code point value. This parameter is only used if `comparator` is
+      a string or an array of property names. Setting this parameter to `true`
+      results in generally slower sorts for string properties, but may be
+      necessary if the properties are locale-sensitive.
 
 #### Returns
 
@@ -645,7 +657,7 @@ query
     same group.
   - If a string is passed in, then the query elements are sorted by that
     property in ascending order. If the property itself is a string, then
-    [String.prototype.localeCompare()][] is used to sort the query results; if
+    the sorting strategy is determined by the `localeCompare` option; if
     the property is an object with a `diff()` function, then this function is
     expected to have the same spec as the callback in
     [Array.prototype.sort()][], and it is used to sort the query results.
@@ -667,12 +679,12 @@ query
       already sorted according to `comparator`. This provides a significant
       performance boost. Default is `false`.
     - `localeCompare` (boolean): If `true`, this signifies that strings should
-      be sorted using the `localeCompare` function. If `false` (default),
-      strings are sorted according to each character's Unicode code point value.
-      This parameter is only used if `comparator` is a string or an array of
-      property names.  Setting this parameter to `true` results in  generally
-      slower sorts for string properties, but may be necessary if the properties
-      are locale-sensitive.
+      be sorted using the [String.prototype.localeCompare()][] function. If
+      `false` (default), strings are sorted according to each character's
+      Unicode code point value. This parameter is only used if `comparator` is
+      a string or an array of property names. Setting this parameter to `true`
+      results in generally slower sorts for string properties, but may be
+      necessary if the properties are locale-sensitive.
 
 #### Returns
 
@@ -691,22 +703,23 @@ Inspect the current query result using the provided callback.
 
 This may be inserted in the middle of query construction to inspect or extract
 the array at that point in execution. The provided `callback` function will be
-called with the result array as its only argument. This is similar to using the
-notify callback when calling `.execute({async: true})`, except that (unlike
-the notify callback) different `.inspect()` callbacks may be inserted at
-different points in the query execution.
+called with the result array as its only argument.
 
-The main difference between this function and `.execute()` is that instead of
+The main difference between this function and `execute` is that instead of
 an array or a promise, this function returns the query object, allowing you to
 continue constructing your query. Also, like other operations, the callback is
-not executed until `.execute()` is called.
+not executed until `execute` is called.
 
 The two main use-cases for this function are debugging and efficiency.
 For example, the intermediate results in the Fluent Demo on the
 [documentation page][docs] were constructed using `.inspect()` inserted at
-various points within the construction of a single query. This is more
-efficient and less code than construcing/executing multiple queries for each
-step.
+various points within the construction of a single query, which allows us to see
+each step of the query with less code than constructing/executing multiple
+queries.
+
+Like all other query operations, `inspect` is not executed if the cache is used.
+To force all operations (including `inspect`) to be executed, use the
+`{force:true}` option of `execute`.
 
 
 #### Syntax
@@ -744,7 +757,7 @@ above, `Join.operation(input, ...)` is equivalent to
 
 The static versions currently do not have an asynchronous mode. That is,
 there is no way to have them return a [promise object][] instead of the
-resulting array, as can be done on query objects with `.execute({async:true})`.
+resulting array, as can be done on query objects with `.execute({async: true})`.
 
 
 [docs]: http://atavakoli.github.io/angular-join

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ one place and executed in another. If called with the `{async: true}` option,
 a [promise object][] is returned instead, which is resolved with the final
 array and notified with the intermediate results of each operation in the query.
 
+Query objects are instances of `JoinQuery` and are immutable; each operation
+(with the exception of `execute`) results in the creation of a new object.
+
 
 ### selectFrom
 

--- a/angular-join.js
+++ b/angular-join.js
@@ -445,7 +445,7 @@ angular.module('angular-join', [])
   function selectFrom(input, selectCallback) {
     var query = new JoinQuery(input);
 
-    if (typeof selectCallback == 'function') {
+    if (selectCallback !== undefined && selectCallback !== null) {
       query = query.select(selectCallback);
     }
 

--- a/angular-join.js
+++ b/angular-join.js
@@ -402,16 +402,18 @@ angular.module('angular-join', [])
       if (options && options.async) {
         var deferred = $q.defer();
 
-        if (!(options && options.force) && this.result !== null) {
-          deferred.resolve(this.result);
-        } else if (this.a instanceof JoinQuery) {
+        if (this.a instanceof JoinQuery) {
           var self = this;
           this.a.execute(options).then(function(result) {
-            self.result = result;
-            if (self.op) {
-              self.result = self.op.apply(self.result, self.params);
+            if (!(options && options.force) && self.result !== null) {
+              deferred.resolve(self.result);
+            } else {
+              self.result = result;
+              if (self.op) {
+                self.result = self.op.apply(self.result, self.params);
+              }
+              deferred.resolve(self.result);
             }
-            deferred.resolve(self.result);
           });
         } else {
           this.result = this.a;

--- a/test/unit/fluent.spec.js
+++ b/test/unit/fluent.spec.js
@@ -1,0 +1,160 @@
+describe('using the fluent interface', function() {
+  var Join
+  var $timeout;
+  var $rootScope;
+
+  beforeEach(module('angular-join'));
+  beforeEach(inject(function(_Join_, _$timeout_, _$rootScope_) {
+    Join = _Join_;
+    $timeout = _$timeout_;
+    $rootScope = _$rootScope_;
+  }));
+
+  var left =  [
+    { x: 1, y: 1 },
+    { x: 2, y: 2 },
+    { x: 3, y: 3 },
+    { x: 4, y: 4 }
+  ];
+
+  var right = [
+    { x: 1, y: 1, z: 5 },
+    { x: 2, y: 2, z: 6 },
+    { x: 3, y: 3, z: 7 },
+    { x: 5, y: 5, z: 8 }
+  ];
+
+  it('should create new queries from existing queries', function() {
+    var firstQuery = Join.selectFrom(left);
+    var childQuery = Join.selectFrom(firstQuery, 'x');
+    expect(firstQuery).not.toBe(childQuery);
+  });
+
+  it('should create new queries for mutable operations', function() {
+    var firstQuery = Join.selectFrom(left);
+    var childQuery;
+
+    childQuery = firstQuery.select('x');
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.map('x');
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.where(function() {});
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.having(function() {});
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.filter(function() {});
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.orderBy('x');
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.sort('x');
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.limit(1);
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.offset(1);
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.slice();
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.hashJoin(right, 'x', function() {});
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.mergeJoin(right, 'x', function() {});
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.hashGroupBy('x', function() {});
+    expect(firstQuery).not.toBe(childQuery);
+
+    childQuery = firstQuery.sortGroupBy('x', function() {});
+    expect(firstQuery).not.toBe(childQuery);
+  });
+
+  it('should let base queries change without affecting child queries', function() {
+    var firstQuery = Join.selectFrom(left);
+    var childQuery = firstQuery.select('x');
+
+    var result1 = childQuery.execute();
+    firstQuery = firstQuery.select('y');
+    var result2 = childQuery.execute();
+
+    expect(result1).toEqual(result2);
+  });
+
+  it('should not use the cache when forced', function() {
+    var spy = jasmine.createSpy('spy');
+
+    var firstQuery = Join
+      .selectFrom(left)
+      .inspect(spy);
+
+    var childQuery = firstQuery
+      .select('x')
+      .inspect(spy);
+
+
+    firstQuery.execute();
+    var childResults1 = childQuery.execute({ force: true });
+    expect(spy.calls.count()).toEqual(3);
+
+    var childResults2 = childQuery.execute({ force: true });
+    expect(spy.calls.count()).toEqual(5);
+    expect(childResults1).not.toBe(childResults2);
+
+    childQuery = childQuery.inspect(spy);
+
+    childQuery.execute({ force: true });
+    expect(spy.calls.count()).toEqual(8);
+  });
+
+  it('should use the cache by default', function() {
+    var spy = jasmine.createSpy('spy');
+
+    var firstQuery = Join
+      .selectFrom(left)
+      .inspect(spy);
+
+    var childQuery = firstQuery
+      .select('x')
+      .inspect(spy);
+
+    firstQuery.execute();
+    var childResults1 = childQuery.execute();
+    expect(spy.calls.count()).toEqual(2);
+
+    var childResults2 = childQuery.execute();
+    expect(spy.calls.count()).toEqual(2);
+    expect(childResults1).toBe(childResults2);
+
+    childQuery = childQuery.inspect(spy);
+
+    childQuery.execute();
+    expect(spy.calls.count()).toEqual(3);
+  });
+
+  describe('in async mode', function() {
+    it('should return a promise with the same results', function(done) {
+      var query = Join
+        .selectFrom(left)
+        .select(['y']);
+
+      var promise = query.execute({ async: true });
+      var result = query.execute();
+
+      expect(promise.then).toEqual(jasmine.any(Function));
+
+      promise.then(function(asyncResult) {
+        expect(result).toEqual(asyncResult);
+        done();
+      });
+      $rootScope.$apply();
+    });
+  });
+});

--- a/test/unit/fluent.spec.js
+++ b/test/unit/fluent.spec.js
@@ -112,6 +112,7 @@ describe('using the fluent interface', function() {
 
     childQuery.execute({ force: true });
     expect(spy.calls.count()).toEqual(8);
+
   });
 
   it('should use the cache by default', function() {
@@ -156,5 +157,94 @@ describe('using the fluent interface', function() {
       });
       $rootScope.$apply();
     });
+
+    it('should not use the cache when forced', function(done) {
+      var spy = jasmine.createSpy('spy');
+
+      var firstQuery = Join
+        .selectFrom(left)
+        .inspect(spy);
+      var childQuery = firstQuery
+        .select('x')
+        .inspect(spy);
+
+      var childResults1;
+
+      firstQuery
+        .execute({ async: true, force: true })
+        .then(function(results) {
+          expect(spy.calls.count()).toEqual(1);
+        })
+        .then(function() {
+          return childQuery.execute({ async: true, force: true });
+        })
+        .then(function(results) {
+          childResults1 = results;
+          expect(spy.calls.count()).toEqual(3);
+        })
+        .then(function() {
+          return childQuery.execute({ async: true, force: true });
+        })
+        .then(function(results) {
+          expect(childResults1).not.toBe(results);
+          expect(spy.calls.count()).toEqual(5);
+        })
+        .then(function() {
+          return childQuery
+            .inspect(spy)
+            .execute({ async: true, force: true });
+        })
+        .then(function(results) {
+          expect(spy.calls.count()).toEqual(8);
+          done();
+        });
+
+      $rootScope.$apply();
+    });
+
+    it('should use the cache by default', function(done) {
+      var spy = jasmine.createSpy('spy');
+
+      var firstQuery = Join
+        .selectFrom(left)
+        .inspect(spy);
+      var childQuery = firstQuery
+        .select('x')
+        .inspect(spy);
+
+      var childResults1;
+
+      firstQuery
+        .execute({ async: true })
+        .then(function(results) {
+          expect(spy.calls.count()).toEqual(1);
+        })
+        .then(function() {
+          return childQuery.execute({ async: true });
+        })
+        .then(function(results) {
+          childResults1 = results;
+          expect(spy.calls.count()).toEqual(2);
+        })
+        .then(function() {
+          return childQuery.execute({ async: true });
+        })
+        .then(function(results) {
+          expect(childResults1).toBe(results);
+          expect(spy.calls.count()).toEqual(2);
+        })
+        .then(function() {
+          return childQuery
+            .inspect(spy)
+            .execute({ async: true });
+        })
+        .then(function(results) {
+          expect(spy.calls.count()).toEqual(3);
+          done();
+        });
+
+      $rootScope.$apply();
+    });
+
   });
 });

--- a/test/unit/join.spec.js
+++ b/test/unit/join.spec.js
@@ -1,4 +1,4 @@
-describe('joining two arrays', function() {
+describe('joining', function() {
   var Join;
 
   beforeEach(module('angular-join'));
@@ -311,7 +311,7 @@ describe('joining two arrays', function() {
     }
   ];
 
-  describe('using a hash-join algorithm', function() {
+  describe('using the hashJoin algorithm', function() {
     var permutationOf = function(a2) {
       return {
         asymmetricMatch: function(a1) {
@@ -397,9 +397,50 @@ describe('joining two arrays', function() {
       });
     });
 
+    describe('called fluently with two queries', function() {
+      tests.forEach(function(t) {
+        describe('should do ' + t.name, function() {
+          var rightQuery;
+          beforeEach(function() {
+            rightQuery = Join.selectFrom(t.right);
+          });
+
+          if (t.hasOwnProperty('hash')) {
+            it('with a function', function() {
+              var result = Join
+                .selectFrom(t.left)
+                .hashJoin(rightQuery, t.hash, t.join)
+                .execute();
+              expect(result).toEqual(permutationOf(t.expected));
+            });
+          }
+
+          if (t.hasOwnProperty('field')) {
+            it('with a string', function() {
+              var result = Join
+                .selectFrom(t.left)
+                .hashJoin(rightQuery, t.field, t.join)
+                .execute();
+              expect(result).toEqual(permutationOf(t.expected));
+            });
+          }
+
+          if (t.hasOwnProperty('fields')) {
+            it('with an array', function() {
+              var result = Join
+                .selectFrom(t.left)
+                .hashJoin(rightQuery, t.fields, t.join)
+                .execute();
+              expect(result).toEqual(permutationOf(t.expected));
+            });
+          }
+        });
+      });
+    });
+
   });
 
-  describe('using a merge-join algorithm', function() {
+  describe('using the mergeJoin algorithm', function() {
     describe('called statically', function() {
       tests.forEach(function(t) {
         describe('should do ' + t.name, function() {
@@ -465,6 +506,53 @@ describe('joining two arrays', function() {
                 var result = Join
                   .selectFrom(t.left)
                   .mergeJoin(t.right, t.fields, t.join, opt)
+                  .execute();
+                expect(result).toEqual(t.expected);
+              });
+            }
+          });
+          });
+        });
+      });
+    });
+
+    describe('called fluently with two queries', function() {
+      tests.forEach(function(t) {
+        describe('should do ' + t.name, function() {
+          var options = t.options || [null];
+
+          options.forEach(function(opt) {
+          describe('with ' + JSON.stringify(opt) + ' options', function() {
+            var rightQuery;
+            beforeEach(function() {
+              rightQuery = Join.selectFrom(t.right);
+            });
+
+            if (t.hasOwnProperty('comparator')) {
+              it('with a function', function() {
+                var result = Join
+                  .selectFrom(t.left)
+                  .mergeJoin(rightQuery, t.comparator, t.join, opt)
+                  .execute();
+                expect(result).toEqual(t.expected);
+              });
+            }
+
+            if (t.hasOwnProperty('field')) {
+              it('with a string', function() {
+                var result = Join
+                  .selectFrom(t.left)
+                  .mergeJoin(rightQuery, t.field, t.join, opt)
+                  .execute();
+                expect(result).toEqual(t.expected);
+              });
+            }
+
+            if (t.hasOwnProperty('fields')) {
+              it('with an array', function() {
+                var result = Join
+                  .selectFrom(t.left)
+                  .mergeJoin(rightQuery, t.fields, t.join, opt)
                   .execute();
                 expect(result).toEqual(t.expected);
               });


### PR DESCRIPTION
Fixes #5, #12

Queries are now defined recursively (`instanceof JoinQuery`), such that each query contains a reference to another query, and does _exactly one_ operation on the results of that referenced query.

There is also the base-case `JoinQuery` that just returns an array and does no operation (this is what `Join.selectFrom` creates).

Caching of results was also added, so that the same query is not re-executed, which helps in using one query as a baseline for other queries. The default is to use a cached result; to ignore the cache and force re-execution (e.g. because inputs/options changed), `.execute({ force: true })` may be used.

The `notify` feature of async execution was **deprecated**; I don't think it'll really be used (especially because `inspect` exists) and can create confusion when cached results are used (i.e. `notify` is not called because the query is not traversed once we hit a cached result).

A few bugfixes were also made:
- Missing injection of `$q` was added
- Redundant call to `selectCallback` in `selectFrom`
- String and array callbacks were being ignored in `selectFrom`
- `Array.isArray` was being called incorrectly in `normalizeSelect`
